### PR TITLE
Make the project Leiningen-compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
 /.nrepl-port
 /out
-/project.clj
 /node_modules

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -1,0 +1,4 @@
+(ns dev
+  (:require
+   ;; See https://gist.github.com/jacobobryant/bcc6bef1fb9c5803115e2514f8d85fa1
+   [hyperfiddle.readers]))

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,21 @@
+(defproject hyperfiddle "_"
+  :dependencies ~(->> "deps.edn"
+                      slurp
+                      read-string
+                      :deps
+                      (mapv (fn [[k v]]
+                              [k (:mvn/version v)]))
+                      (into '[[org.clojure/core.async "0.7.559"]
+                              [com.datomic/client-impl-shared "0.8.69"]]))
+
+  :profiles {:dev  {:source-paths ["dev"]
+                    :repl-options {:init-ns dev}}
+
+             :test {:dependencies ~(->> "deps.edn"
+                                        slurp
+                                        read-string
+                                        :aliases
+                                        :test-clj
+                                        :extra-deps
+                                        (mapv (fn [[k v]]
+                                                [k (:mvn/version v)])))}})

--- a/src/contrib/eval_cljs.clj
+++ b/src/contrib/eval_cljs.clj
@@ -1,5 +1,6 @@
 (ns contrib.eval-cljs
-  (:require [contrib.template :refer [load-resource]]))
+  (:require [cljs.env]
+            [contrib.template :refer [load-resource]]))
 
 
 (defmacro build-cljsjs-empty-state []


### PR DESCRIPTION
## Context

It can be desirable for a variety of contributors to hack on Hyperfiddle. Such contributors might have a preferred (or legacy) setup, with an excessive cost of change.

## Proposed changes

Add a thin project.clj that simply reuses the deps.edn contents.

Special attention was paid into making the data-readers part work correctly.

> No "Reloaded" setup is introduced, since that can vary per-contributor. IME that's best configured either in ~/.lein/profiles.clj, or one's IDE.

## QA

I can `(refresh)` repeatedly:

![image](https://user-images.githubusercontent.com/1162994/73532526-27299b80-441d-11ea-9609-82f1855c7241.png)
